### PR TITLE
Suppress model-generated warnings in integration tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -84,8 +84,9 @@ PartitionedLS = "19f41c5e-8610-11e9-2f2a-0d67e7c5027f"
 SIRUS = "cdeec39e-fb35-4959-aadb-a1dd5dede958"
 SelfOrganizingMaps = "ba4b7379-301a-4be0-bee6-171e4e152787"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 SymbolicRegression = "8254be44-1295-4e6a-a16d-46603ac705cb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BetaML", "CatBoost", "EvoLinear", "EvoTrees", "Imbalance", "InteractiveUtils", "LightGBM", "MLJClusteringInterface", "MLJDecisionTreeInterface", "MLJFlux", "MLJGLMInterface", "MLJLIBSVMInterface", "MLJLinearModels", "MLJMultivariateStatsInterface", "MLJNaiveBayesInterface", "MLJScikitLearnInterface", "MLJTSVDInterface", "MLJTestInterface", "MLJTestIntegration", "MLJText", "MLJXGBoostInterface", "Markdown", "NearestNeighborModels", "OneRule", "OutlierDetectionNeighbors", "OutlierDetectionPython", "ParallelKMeans", "PartialLeastSquaresRegressor", "PartitionedLS", "SelfOrganizingMaps", "SIRUS", "SymbolicRegression", "StableRNGs", "Test"]
+test = ["BetaML", "CatBoost", "EvoLinear", "EvoTrees", "Imbalance", "InteractiveUtils", "LightGBM", "MLJClusteringInterface", "MLJDecisionTreeInterface", "MLJFlux", "MLJGLMInterface", "MLJLIBSVMInterface", "MLJLinearModels", "MLJMultivariateStatsInterface", "MLJNaiveBayesInterface", "MLJScikitLearnInterface", "MLJTSVDInterface", "MLJTestInterface", "MLJTestIntegration", "MLJText", "MLJXGBoostInterface", "Markdown", "NearestNeighborModels", "OneRule", "OutlierDetectionNeighbors", "OutlierDetectionPython", "ParallelKMeans", "PartialLeastSquaresRegressor", "PartitionedLS", "SelfOrganizingMaps", "SIRUS", "SymbolicRegression", "StableRNGs", "Suppressor","Test"]

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -201,6 +201,7 @@ problems = []
 
 const nmodels = length(JULIA_MODELS) + length(OTHER_MODELS)
 i = 0
+println()
 for (model_set, level) in [
     (:JULIA_MODELS, JULIA_TEST_LEVEL),
     (:OTHER_MODELS, OTHER_TEST_LEVEL),
@@ -211,16 +212,15 @@ for (model_set, level) in [
         verbosity = 0, # bump to 2 to debug
         throw = false,
     )
-    println()
     @testset "$model_set tests" begin
         for model in set
             global i += 1
-            progress = string("(", round(i/nmodels*100, digits=1), "%) ")
+            progress = string("(", round(i/nmodels*100, digits=1), "%) Testing: ")
 
             # exclusions:
             model in WITHOUT_DATASETS && continue
 
-            notice = "Testing $(model.name) ($(model.package_name))"
+            notice = "$(model.name) ($(model.package_name))"
             print("\r", progress, notice, "                       ")
 
             okay = @suppress isempty(MLJTestIntegration.test(

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -205,8 +205,8 @@ for (model_set, level) in [
     (:JULIA_MODELS, JULIA_TEST_LEVEL),
     (:OTHER_MODELS, OTHER_TEST_LEVEL),
     ]
-    i += 1
-    progress = string("(", round(i/nmodels*100, sigdigits=2), "%) ")
+    global i += 1
+    progress = string("(", round(i/nmodels*100, digits=1), "%) ")
     set = eval(model_set)
     options = (
         ; level,

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -211,9 +211,8 @@ for (model_set, level) in [
         verbosity = 0, # bump to 2 to debug
         throw = false,
     )
-
+    println()
     @testset "$model_set tests" begin
-        println()
         for model in set
             global i += 1
             progress = string("(", round(i/nmodels*100, digits=1), "%) ")

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -27,8 +27,6 @@ FILTER_GIVEN_ISSUE = Dict(
         model.package_name == "DecisionTree") ||
         (model.name == "COFDetector" &&
         model.package_name == "OutlierDetectionNeighbors"),
-    "https://github.com/JuliaAI/CatBoost.jl/pull/28 (waiting for 0.3.3 release)" =>
-        model -> model.name == "CatBoostRegressor",
     "https://github.com/JuliaML/LIBSVM.jl/issues/98" =>
         model -> model.name == "LinearSVC" &&
         model.package_name == "LIBSVM",
@@ -40,12 +38,8 @@ FILTER_GIVEN_ISSUE = Dict(
     "https://github.com/sylvaticus/BetaML.jl/issues/65" =>
         model -> model.name in ["KMeans", "KMedoids"] &&
         model.package_name == "BetaML",
-    "https://github.com/JuliaAI/MLJTSVDInterface.jl/pull/17" =>
-        model -> model.name == "TSVDTransformer",
     "https://github.com/JuliaAI/MLJ.jl/issues/1074" =>
         model -> model.name == "AutoEncoderMLJ",
-    "https://github.com/sylvaticus/BetaML.jl/issues/64" =>
-        model -> model.name =="GaussianMixtureClusterer" && model.package_name=="BetaML",
      "https://github.com/rikhuijzer/SIRUS.jl/issues/78" =>
         model -> model.package_name == "SIRUS",
     "https://github.com/lalvim/PartialLeastSquaresRegressor.jl/issues/29 "*

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -238,7 +238,8 @@ for (model_set, level) in [
 end
 
 okay = isempty(problems)
-okay || println("Integration tests failed for these models: \n $problems")
+okay || print("Integration tests failed for these models: \n $problems")
+println()
 
 @test okay
 

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -205,8 +205,6 @@ for (model_set, level) in [
     (:JULIA_MODELS, JULIA_TEST_LEVEL),
     (:OTHER_MODELS, OTHER_TEST_LEVEL),
     ]
-    global i += 1
-    progress = string("(", round(i/nmodels*100, digits=1), "%) ")
     set = eval(model_set)
     options = (
         ; level,
@@ -217,6 +215,8 @@ for (model_set, level) in [
     @testset "$model_set tests" begin
         println()
         for model in set
+            global i += 1
+            progress = string("(", round(i/nmodels*100, digits=1), "%) ")
 
             # exclusions:
             model in WITHOUT_DATASETS && continue

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -6,6 +6,17 @@ using Suppressor
 const JULIA_TEST_LEVEL = 4
 const OTHER_TEST_LEVEL = 3
 
+# # IMPORTANT
+
+# There are two main ways to flag a problem model for integration test purposes.
+
+# - Adding to `FILTER_GIVEN_ISSUE` means the model is allowed to fail silently, unless
+#  tests pass, a fact that will be reported in the log.
+
+# - Adding to `PATHOLOGIES` completely excludes the model from testing.
+
+# Obviously the first method is strongly preferred.
+
 
 # # RECORD OF OUTSTANDING ISSUES
 
@@ -194,10 +205,14 @@ const INFO_TEST_NOW_PASSING =
 
 problems = []
 
+const nmodels = length(JULIA_MODELS) + length(OTHER_MODELS)
+i = 0
 for (model_set, level) in [
     (:JULIA_MODELS, JULIA_TEST_LEVEL),
     (:OTHER_MODELS, OTHER_TEST_LEVEL),
     ]
+    i += 1
+    progress = string("(", round(i/nmodels*100, sigdigits=2), "%) ")
     set = eval(model_set)
     options = (
         ; level,
@@ -213,7 +228,7 @@ for (model_set, level) in [
             model in WITHOUT_DATASETS && continue
 
             notice = "Testing $(model.name) ($(model.package_name))"
-            print("\r", notice, "                       ")
+            print("\r", progress, notice, "                       ")
 
             okay = @suppress isempty(MLJTestIntegration.test(
                 model;


### PR DESCRIPTION
Currently it's painful to check the log for integration tests  because some models have a low bar for issuing warnings that are almost certainly irrelevant for the purposes of the integration tests. 

In this PR we suppress these warnings. We also:

- Test *all* models not in the `PATHOLOGIES` category, with models flagged using `FILTER_GIVEN_ISSUE` allowed to silently fail, unless they *pass* tests, a fact we now report in the log.  Previously these latter models were just ignored, along with `PATHOLOGIES`. 
- Reinstate some models in integration tests previously flagged in issues but now sorted
- Tidy up test code to reduce some duplication
- Move "MLJSckitLearnInterface" models in to PATHOLOGIES for now. These add a lot to overall test time. I will post an issue suggesting we might return these to integration tests in the future.

**Note:** Integration tests are actually skipped in this preliminary PR. They become active in a PR onto `master`. 