### PR TITLE
Add a draft governance document

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,164 @@
+# DRAFT DOCUMENT ONLY
+
+# Governance in MLJ
+
+The following contains the formal governance structure of the Machine Learning in Julia
+project (MLJ). This project maintains and develops the open source software hosted by
+the [JuliaAI](https://github.com/JuliaAI) GitHub organization. This document clarifies how
+decisions are made with respect to community interactions, including the relationship
+between open source development and work that may be funded by for-profit and non-profit
+entities.
+
+## Code of Conduct
+
+The MLJ community values inclusivity and diversity. Everyone should treat others with
+utmost respect. Everyone in the community must adhere to the [MLJ Code of
+Conduct](https://github.com/JuliaAI/MLJ.jl/blob/dev/CODE_OF_CONDUCT.md) which reflects the
+values of our community. Violations of the code should be reported to members of the
+Steering Council, where the offenses will be handled on a case-by-case basis.
+
+## Current Steering Council
+
+- Dr. Anthony Blaom, University of Auckland (<anthony.blaom@gmail.com>)
+
+- Professor Sebastian Vollmer, German Research Center for Artificial Intelligence (DFKI),
+  RPTU (<sebastian.vollmer@dfki.de>)
+
+- Professor Mark Gahegan, University of Auckland (<m.gahegan@auckland.ac.nz>)
+
+## Advisory Committee
+
+To be appointed
+
+## Governing Rules and Duties
+
+### Steering Council
+
+The role of the Steering Council is to provide active leadership for the Project in making
+everyday decisions on technical and administrative issues, through working with and taking
+input from the Community.
+
+During the everyday project activities, Council Members participate in all discussions,
+code review and other project activities as peers with all other Contributors and the
+Community. In these everyday activities, Council Members do not have any special power or
+privilege through their membership on the Council. However, because of the quality and
+quantity of their own contributions to the project and their expert knowledge of the
+Project Software and Services, Council Members are expected to provide useful guidance,
+both technical and in terms of project direction, to potentially less experienced
+Contributors.
+
+The Steering Council and its Members play a special role in certain situations. In
+particular, the Council may make decisions regarding:
+
+- The overall scope, vision and direction of the project.
+
+- The strategic collaborations with other organizations or individuals.
+
+- Specific technical issues, features, bugs and pull requests. They
+  are the primary mechanism of guiding the code review process and merging pull requests.
+
+- Services that are run by the Project and manage those Services
+  for the benefit of the Project and Community.
+
+- The appointment of new Members to the Steering Council and
+  Advisory Committee, subject to procedures outlined below.
+  
+- Community discussions on proposals where consensus has not been reached in a reasonable
+  time frame.
+
+Steering Council decisions are taken by simple majority, with the exception of changes to
+these Governance Documents, which follow the procedure in the section 'Changing the
+Governance Documents'.
+
+### Steering Council Membership
+
+Potential Council Members are nominated by existing Council Members or by the Community
+and voted upon by the existing Council after confirming the potential Member is willing to
+serve in that capacity. The Ideal Candidate will: (i) have made contributions to the MLJ
+project that are substantial in quality and quantity, and sustained over at least six
+months; and (ii) have demonstrably broad familiarity with Machine Learning
+practices. Candidates satisfying (ii) but not (i) may also be considered, but only if all
+the following conditions are met:
+
+- The need for a new Steering Council Member is acute.
+
+- The Candidate under consideration has made comparable contributions to another open
+  source software project related to Machine Learning.
+
+- All reasonable efforts to identify a willing Ideal Candidate have failed.
+
+When considering potential Members, the Council will look at candidates with a
+comprehensive view of their contributions. This will include but is not limited to code,
+code review, infrastructure work, mailing list and chat participation, community
+help/building, education and outreach, and design work.
+
+A Council Member can only be removed in one of the following ways:
+
+- The Member resigns.
+
+- The Member has been inactive in the project for a period of one year and agrees to be
+  removed upon the request of another Member.
+
+- The Member has been inactive in the project for a period of two years, and a majority of
+  the other Members agree to have the inactive member removed.
+
+- The Member has, in the view of a majority of other Members, actively engaged in behavior
+  harmful to the Project's well-being, and attempts at communication and conflict
+  resolution have failed.
+
+All former Council members can be considered for membership again at any time in the
+future, like any other Project Contributor. Retired Council Members and their years of
+service will be acknowledged on the project website.
+
+### Fiscal Decisions
+
+All fiscal decisions are made by the Steering Council to ensure any funds are spent in a
+manner that furthers the mission of the Project. Fiscal decisions require majority
+approval by acting Steering Council Members.
+
+### Advisory Committee
+
+The Project has an Advisory Committee that works to ensure the long-term well-being of the
+Project. The Committee advises the Steering Council and may be called upon to break
+deadlocks or serious disagreements in the Council. The Community can ask the Committee to
+review actions taken by the Council, and the Committee will meet each year to review
+Project activities. Committee decisions are taken by consensus. Members of the Advisory
+Committee are appointed by the Steering Council. A Member of the Advisory Committee can
+request to be removed from the Committee at any time.
+
+### Conflict of Interest
+
+It is expected that Steering Council and Advisory Committee Members will be employed at a
+wide range of companies, universities and non-profit organizations. Because of this, it is
+possible that Members will have conflicts of interest. Such conflicts of interest include,
+but are not limited to:
+
+Financial interests, such as investments, employment or contracting work, outside of the
+Project that may influence their work on the Project.
+
+Access to proprietary information of their employer that could potentially leak into their
+work with the Project.
+
+All members of the Council and Committee shall disclose any conflict of interest they may
+have. Members with a conflict of interest in a particular issue may participate in Council
+discussions on that issue, but must recuse themselves from voting on the issue.
+
+### Changing the Governance Document
+
+Changes to this governance document may be proposed by any member of the MLJ Community, by
+opening a pull request (PR). The source of this document resides at
+[github.com/JuliaA/MLJ/GOVERNANCE.md](https://github.com/JuliaA/GOVERNANCE.md).  The
+Steering Council may immediately merge requests that do not materially effect the rules of
+governance. Such changes include correcting false information and updating the lists of
+Council or Committee members. Proposals materially effecting the rules of governance must
+explain the reasons for the change and include a statement inviting members of the
+Community to provide their feedback on the proposal. Members of the Steering Council will
+facilitate a discussion seeking consensus on whether to accept or reject the proposed
+changes. After a reasonable period, not less than 28 days, the Steering Council will vote
+either to merge or close the PR. If at least 2/3 of the Council vote to accept the
+changes, the PR will be merged and otherwise it will be closed. While it is expected that
+the Council Members make a good faith attempt to consider the majority view
+articulated in the Community discussion, Members are not bound by those views.
+
+If Council unanimously agrees that a proposal to change the Governance Document is frivolous,
+it may reject it immediately without Community review.


### PR DESCRIPTION
This is approximately modelled on the Flux document.

I'll leave this open for comment until at least the end of June, 2024.

I'm considering applying to make MLJ a NumFocus ["Fiscally Sponsored Project"](https://numfocus.org/projects-overview). This doesn't fund the project per se, but hopefully makes it more attractive and easier for agencies/companies to fund the project. NumFocus is a US non-profit. If there are other suggestions for achieving these goals, feel free to comment here. 