### PR TITLE
Update target_transformations.md

### DIFF
--- a/docs/src/target_transformations.md
+++ b/docs/src/target_transformations.md
@@ -69,9 +69,6 @@ X, y = @load_boston
 evaluate(ridge3, X, y, measure=l1)
 ```
 
-Without the log transform (ie, using `ridge`) we get the poorer mean absolute error,
-`l1`, of 3.9.
-
 ```@docs
 TransformedTargetModel
 ```


### PR DESCRIPTION
This sentence doesn't seem to relate to the examples (ridge and ridge2) on rest of the page which use a different dataset. 

Perhaps the two examples for ridge and ridge2 were supposed to use the load_boston dataset as well?