### PR TITLE
Integration of new landing page into docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,19 @@
     <img src="material/MLJLogo2.svg" alt="MLJ" width="200">
 </div>
 
-<h2 align="center">A Machine Learning Framework for Julia
+<h2 align="center">A Machine Learning Toolbox for Julia
 <p align="center">
   <a href="https://github.com/JuliaAI/MLJ.jl/actions">
     <img src="https://github.com/JuliaAI/MLJ.jl/workflows/CI/badge.svg"
          alt="Build Status">
   </a>
   <a href="https://JuliaAI.github.io/MLJ.jl/dev/">
+    <img src="https://img.shields.io/badge/docs-dev-blue.svg"
+         alt="dev documentation">
+  </a>
+  <a href="https://JuliaAI.github.io/MLJ.jl/stable/">
     <img src="https://img.shields.io/badge/docs-stable-blue.svg"
-         alt="Documentation">
+         alt="stable documentation">
   </a>
   <a href="https://opensource.org/licenses/MIT">
     <img src="https://img.shields.io/badge/License-MIT-yelllow"
@@ -25,82 +29,20 @@
 </h2>
 
 
-MLJ (Machine Learning in Julia) is a toolbox written in Julia
-providing a common interface and meta-algorithms for selecting,
-tuning, evaluating, composing and comparing about [200 machine learning
-models](https://JuliaAI.github.io/MLJ.jl/dev/model_browser/#Model-Browser)
-written in Julia and other languages.
+MLJ (Machine Learning in Julia) is a toolbox written in Julia providing a common interface
+and meta-algorithms for selecting, tuning, evaluating, composing and comparing over [200
+machine learning
+models](https://JuliaAI.github.io/MLJ.jl/stable/model_browser/#Model-Browser) written in
+Julia and other languages.
 
-**New to MLJ?** Start [here](https://JuliaAI.github.io/MLJ.jl/dev/).
+The MLJ.jl package is an umbrella package for components distributed in a number of [other packages](https://juliaml.ai/ecosystem). 
+
+**New to MLJ?** Start [here](https://juliaml.ai).
+
+**Documentation** is [here](https://JuliaAI.github.io/MLJ.jl/stable/)
 
 **Integrating an existing machine learning model into the MLJ
-framework?** Start [here](https://JuliaAI.github.io/MLJ.jl/dev/quick_start_guide_to_adding_models/).
-
-**Wanting to contribute?** Start [here](CONTRIBUTING.md). 
-
-**PhD and Postdoc opportunies** See [here](https://sebastian.vollmer.ms/jobs/).
-
-MLJ was initially created as a Tools, Practices and Systems project at
-the [Alan Turing Institute](https://www.turing.ac.uk/)
-in 2019. Funding has also been provided by a [New Zealand Strategic
-Science Investment
-Fund](https://www.mbie.govt.nz/science-and-technology/science-and-innovation/funding-information-and-opportunities/investment-funds/strategic-science-investment-fund/ssif-funded-programmes/university-of-auckland/)
-awarded to the University of Auckland.
-
-MLJ has been developed with the support of the following organizations:
-
-<div align="center">
-    <a href="https://www.dfki.de/en/web">
-        <img src="material/DFKI.png" width = 100/>
-    </a>
-    <a href="https://www.turing.ac.uk/">
-        <img src="material/Turing_logo.png" width = 100/>
-    </a>
-    <a href="https://www.auckland.ac.nz/en.html">
-        <img src="material/UoA_logo.png" width = 100/>
-    </a>
-    <a href="https://www.iqvia.com/">
-        <img src="material/IQVIA_logo.png" width = 100/>
-    </a>
-    <a href="https://warwick.ac.uk/">
-        <img src="material/warwick.png" width = 100/>
-    </a>
-    <a href="https://juliahub.com/">
-        <img src="material/julia.png" width = 100/>
-    </a>
-    <a href="https://ethz.ch/en.html">
-        <img src="material/ETH-Zurich.jpg" width = 100/>
-    </a>
-</div>
-
-
-### The MLJ Universe
-
-The functionality of MLJ is distributed over several repositories
-illustrated in the dependency chart below. These repositories live at
-the [JuliaAI](https://github.com/JuliaAI) umbrella organization.
-
-<div align="center">
-    <img src="material/MLJ_stack.svg" alt="Dependency Chart">
-</div>
-
-*Dependency chart for MLJ repositories. Repositories with dashed
-connections do not currently exist but are planned/proposed.*
-
-<br>
-<p align="center">
-<a href="CONTRIBUTING.md">Contributing</a> &nbsp;•&nbsp; 
-<a href="ORGANIZATION.md">Code Organization</a> &nbsp;•&nbsp;
-<a href="ROADMAP.md">Road Map</a> 
-</br>
-
-#### Contributors
-
-*Core design*: A. Blaom, F. Kiraly, S. Vollmer
-
-*Lead contributor*: A. Blaom
-
-*Active maintainers*: A. Blaom, S. Okon, T. Lienart, D. Aluthge
+framework?** Start [here](https://juliaai.github.io/MLJModelInterface.jl/stable/)
 
 
 

--- a/docs/model_docstring_tools.jl
+++ b/docs/model_docstring_tools.jl
@@ -114,7 +114,7 @@ Write the "Model Browser" page at /docs/model_browser.md"
 """
 function write_page()
     header = """
-           # Model Browser
+           # [Model Browser](@id model_browser)
 
            Models may appear under multiple categories.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,9 +8,7 @@
     style="color: #389826;">Install</a>         &nbsp;|&nbsp;
   <a href="learning_mlj"   style="color: #389826;">Learn</a>            &nbsp;|&nbsp;
   <a href="mlj_cheatsheet" style="color: #9558B2;">Cheatsheet</a>       &nbsp;|&nbsp;
-  <a href="common_mlj_workflows" style="color: #9558B2;">Workflows</a>  &nbsp;|&nbsp;
-  <a href="https://github.com/JuliaAI/MLJ.jl/" style="color: #9558B2;">For Developers</a> &nbsp;|&nbsp;
-  <a href="third_party_packages" style="color: #9558B2;">3rd Party Packages</a>
+  <a href="common_mlj_workflows" style="color: #9558B2;">Workflows</a>
 </div>
 
 <span style="color: #9558B2;font-size:4.5em;">
@@ -34,7 +32,9 @@ To support MLJ development, please cite these works or star the repo:
   Star</a>
 ```
 
-# [Model Browser](@ref)
+# Model Browser
+
+[Text Based](@ref model_browser) | [Graphical](https://juliaml.ai/machines) 
 
 # Reference Manual
 

--- a/docs/src/learning_mlj.md
+++ b/docs/src/learning_mlj.md
@@ -1,51 +1,24 @@
 # Learning MLJ
 
-[MLJ Cheatsheet](@ref)
+The main sources for MLJ tutorials are:
 
-See also [Getting help and reporting problems](@ref).
+- [Complete list](https://juliaml.ai/tutorials): structured by topic
+- [Data Science Tutorials](https://juliaai.github.io/DataScienceTutorials.jl): smaller curated collection of tutorials, generally completed in sequence
 
-The present document, although littered with examples, is primarily
-intended as a complete reference. 
-
-## Where to start?
-
-### Completely new to Julia? 
-[Julia's learning resources page](https://julialang.org/learning/) |
-[Learn X in Y minutes](https://learnxinyminutes.com/docs/julia/) |
-[HelloJulia](https://github.com/ablaom/HelloJulia.jl)
-
-### New to data science?
-[Julia Data Science](https://github.com/JuliaDataScience/JuliaDataScience)
-
-### New to machine learning?
-[Introduction to Statistical Learning](https://www.statlearning.com) with Julia versions of  the R labs [here](https://juliaai.github.io/DataScienceTutorials.jl/)
-
-### Know some ML and just want MLJ basics?
-[Getting Started](@ref) | [Common MLJ Workflows](@ref)
-
-### An ML practitioner transitioning from another platform?
-[MLJ for Data Scientists in Two Hours](https://juliaai.github.io/DataScienceTutorials.jl/end-to-end/telco/) |
-[MLJTutorial](https://github.com/ablaom/MLJTutorial.jl)
-
+If you are an ML practitioner transitioning from another platform, we highly recommend
+[MLJ for Data Scientists in Two Hours](https://juliaai.github.io/DataScienceTutorials.jl/end-to-end/telco/).
 
 ## Other resources
 
-- [Data Science Tutorials](https://juliaai.github.io/DataScienceTutorials.jl): MLJ tutorials including end-to-end examples, and "Introduction to Statistical Learning" labs
+- [MLJ Cheatsheet](@ref) (or [here](https://juliaml.ai/mlj-cheatsheet))
 
-- [MLCourse](https://github.com/jbrea/MLCourse): Teaching material for an introductory machine learning course at EPFL (for an interactive preview see [here](https://bio322.epfl.ch)).
+- [Getting help and reporting problems](@ref).
 
-- [Julia Boards the Titanic](https://forem.julialang.org/ablaom/julia-boards-the-titanic-1ne8) Blog post on using MLJ for users new to Julia. 
+- [Julia Data Science](https://github.com/JuliaDataScience/JuliaDataScience)
 
-- [Analyzing the Glass Dataset](https://towardsdatascience.com/part-i-analyzing-the-glass-dataset-c556788a496f): A gentle introduction to data science using Julia and MLJ (three-part blog post)
+- [MLJTutorial](https://github.com/ablaom/MLJTutorial.jl): material for a 4 hour MLJ
+  workshop
 
-- [Lightning Tour](https://github.com/JuliaAI/MLJ.jl/blob/dev/examples/lightning_tour/lightning_tour.ipynb): A compressed demonstration of key MLJ functionality
-
-- [MLJ JuliaCon2020 Workshop](https://github.com/ablaom/MachineLearningInJulia2020): older version of  [MLJTutorial](https://github.com/ablaom/MLJTutorial.jl) with [video](https://www.youtube.com/watch?time_continue=27&v=qSWbCn170HU&feature=emb_title)
-
-- [Learning Networks](@ref): For advanced MLJ users wanting to wrap workflows more complicated than linear pipelines
-
-- [Machine Learning Property Loans for Fun and Profit](https://dm13450.github.io/2022/07/08/Machine-Learning-Property-Loans.html) - Blog post demonstrating the use of MLJ to predict prospects for investment in property development loans. 
-
-- [Predicting a Successful Mt Everest
-  Climb](https://dm13450.github.io/2023/04/27/Predicting-a-Successful-Mt-Everest-Climb.html) -
-  Blog post using MLJ to discover factors correlating with success in expeditions to climb the world's highest peak.
+- [MLCourse](https://github.com/jbrea/MLCourse): Teaching material for an introductory
+  machine learning course at EPFL (for an interactive preview see
+  [here](https://bio322.epfl.ch)).


### PR DESCRIPTION
This PR adds references to the new landing page juliaml.ai into the docs and removes some redundancies created by this new page. 